### PR TITLE
chore: change default running port

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -7,7 +7,7 @@ use Mix.Config
 # watchers to your application. For example, we use it
 # with brunch.io to recompile .js and .css sources.
 config :owlet_chat, OwletChat.Endpoint,
-  http: [port: 4000],
+  http: [port: System.get_env("PORT") || 5000],
   debug_errors: true,
   code_reloader: true,
   check_origin: false,


### PR DESCRIPTION
New port is **5000**
We can also change it on the fly with an inline environment variable like so:
`PORT=3333 mix phoenix.server`

@cjford
